### PR TITLE
Fix for method isOrderIncrementIdUsed.

### DIFF
--- a/app/code/community/Mswebdesign/CustomOrderNumber/Model/Resource/Sales/Quote.php
+++ b/app/code/community/Mswebdesign/CustomOrderNumber/Model/Resource/Sales/Quote.php
@@ -1,0 +1,25 @@
+<?php
+
+class Mswebdesign_CustomOrderNumber_Model_Resource_Sales_Quote extends Mage_Sales_Model_Resource_Quote
+{
+    /**
+     * Check is order increment id use in sales/order table
+     *
+     * @param int $orderIncrementId
+     * @return boolean
+     */
+    public function isOrderIncrementIdUsed($orderIncrementId)
+    {
+        $adapter   = $this->_getReadAdapter();
+        $bind      = array(':increment_id' => $orderIncrementId);
+        $select    = $adapter->select();
+        $select->from($this->getTable('sales/order'), 'entity_id')
+            ->where('increment_id = :increment_id');
+        $entity_id = $adapter->fetchOne($select, $bind);
+        if ($entity_id > 0) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/code/community/Mswebdesign/CustomOrderNumber/etc/config.xml
+++ b/app/code/community/Mswebdesign/CustomOrderNumber/etc/config.xml
@@ -38,6 +38,11 @@
                     <entity_type>Mswebdesign_CustomOrderNumber_Model_Eav_Entity_Type</entity_type>
                 </rewrite>
             </eav>
+            <sales_resource>
+                <rewrite>
+                    <quote>Mswebdesign_CustomOrderNumber_Model_Resource_Sales_Quote</quote>
+                </rewrite>
+            </sales_resource>
         </models>
         <helpers>
             <mswebdesign_customordernumber>


### PR DESCRIPTION
If increment id contain letters, the method "isOrderIncrementIdUsed" always return false. For this reason the cast to int must be remove.